### PR TITLE
fix(core): continue build on error

### DIFF
--- a/github-elpa.el
+++ b/github-elpa.el
@@ -104,7 +104,7 @@ If not throw error."
       (message ":: github-elpa: packaging recipe %s" recipe)
       (let ((package-build-tar-executable (or github-elpa-tar-executable
                                               package-build-tar-executable)))
-        (package-build-archive recipe)))
+        (ignore-errors (package-build-archive recipe))))
     (package-build-cleanup)))
 
 ;;;###autoload
@@ -117,7 +117,7 @@ If not throw error."
         (package-build-recipes-dir
          (expand-file-name github-elpa-recipes-dir)))
     (message ":: github-elpa: Commit packages in %s"
-              package-build-archive-dir)
+             package-build-archive-dir)
     (github-elpa--git-check-repo)
     (github-elpa--git-commit-archives)))
 


### PR DESCRIPTION
Right now the elpa will stop once there is an error occurred. We should continue the build, so it doesn't hamper the build from other packages in the queue.