### PR TITLE
feat(bin): Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 
 # Packaging
 .cask
+.eask
 
 # github-elpa
 .github-elpa-working/
 
 # Cask repository
-
+dist/
 cask-repository/

--- a/Eask
+++ b/Eask
@@ -1,0 +1,16 @@
+(package "github-elpa" "0.0.1" "Build and publish ELPA repositories with GitHub Pages")
+
+(website-url "https://github.com/10sr/github-elpa")
+
+(package-file "github-elpa.el")
+
+(files :defaults "bin")
+
+(source 'gnu)
+(source 'melpa)
+
+(depends-on "package-build")
+(depends-on "commander")
+(depends-on "git")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/bin/github-elpa
+++ b/bin/github-elpa
@@ -94,7 +94,7 @@
  (command "update" "Update elpa repository" github-elpa-bin-update)
  (command "build" "Update elpa archives without committing them"
           github-elpa-bin-build)
- (command "commit" "Commit elpa archives" github-elpa-bin-commmit)
+ (command "commit" "Commit elpa archives" github-elpa-bin-commit)
 
  (option "--working-dir <working-dir>, -w <working-dir>"
          github-elpa-bin-set-working-dir)

--- a/bin/github-elpa.bat
+++ b/bin/github-elpa.bat
@@ -1,0 +1,1 @@
+emacs -batch -Q -l %~dp0github-elpa -- %*


### PR DESCRIPTION
A few changes I have made:

1. There is a typo in `bin/github-elpa`.
2. Add Windows support. (`bin/github-elpa.bat`)
3. Add Eask to test on Windows (Cask has dropped support for legacy Windows)

For #8.